### PR TITLE
Add difficulty selector and length-based word selection

### DIFF
--- a/HangmanApp/HangmanApp/Form1.Designer.cs
+++ b/HangmanApp/HangmanApp/Form1.Designer.cs
@@ -69,10 +69,10 @@
             tblHiddenWord = new TableLayoutPanel();
             lblHiddenWord = new Label();
             tableLayoutPanel1 = new TableLayoutPanel();
-            label1 = new Label();
-            label2 = new Label();
-            label3 = new Label();
-            label4 = new Label();
+            lblBase = new Label();
+            lblPole = new Label();
+            lblBeam = new Label();
+            lblRope = new Label();
             pnlMan = new Panel();
             lblBody = new Label();
             lblRightLeg = new Label();
@@ -191,7 +191,7 @@
             lblDifficulty.Font = new Font("Segoe UI", 10.8F, FontStyle.Bold, GraphicsUnit.Point, 0);
             lblDifficulty.Location = new Point(15, 8);
             lblDifficulty.Name = "lblDifficulty";
-            lblDifficulty.Size = new Size(86, 25);
+            lblDifficulty.Size = new Size(96, 25);
             lblDifficulty.TabIndex = 0;
             lblDifficulty.Text = "Difficulty:";
             // 
@@ -200,9 +200,9 @@
             rdoEasy.Anchor = AnchorStyles.Left;
             rdoEasy.AutoSize = true;
             rdoEasy.Checked = true;
-            rdoEasy.Location = new Point(107, 10);
+            rdoEasy.Location = new Point(117, 9);
             rdoEasy.Name = "rdoEasy";
-            rdoEasy.Size = new Size(60, 24);
+            rdoEasy.Size = new Size(59, 24);
             rdoEasy.TabIndex = 1;
             rdoEasy.TabStop = true;
             rdoEasy.Text = "Easy";
@@ -212,9 +212,9 @@
             // 
             rdoMedium.Anchor = AnchorStyles.Left;
             rdoMedium.AutoSize = true;
-            rdoMedium.Location = new Point(173, 10);
+            rdoMedium.Location = new Point(182, 9);
             rdoMedium.Name = "rdoMedium";
-            rdoMedium.Size = new Size(88, 24);
+            rdoMedium.Size = new Size(85, 24);
             rdoMedium.TabIndex = 2;
             rdoMedium.Text = "Medium";
             rdoMedium.UseVisualStyleBackColor = true;
@@ -223,9 +223,9 @@
             // 
             rdoHard.Anchor = AnchorStyles.Left;
             rdoHard.AutoSize = true;
-            rdoHard.Location = new Point(267, 10);
+            rdoHard.Location = new Point(273, 9);
             rdoHard.Name = "rdoHard";
-            rdoHard.Size = new Size(62, 24);
+            rdoHard.Size = new Size(63, 24);
             rdoHard.TabIndex = 3;
             rdoHard.Text = "Hard";
             rdoHard.UseVisualStyleBackColor = true;
@@ -625,10 +625,10 @@
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 31.25F));
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 3.125F));
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 31.25F));
-            tableLayoutPanel1.Controls.Add(label1, 0, 3);
-            tableLayoutPanel1.Controls.Add(label2, 3, 0);
-            tableLayoutPanel1.Controls.Add(label3, 2, 0);
-            tableLayoutPanel1.Controls.Add(label4, 1, 0);
+            tableLayoutPanel1.Controls.Add(lblBase, 0, 3);
+            tableLayoutPanel1.Controls.Add(lblPole, 3, 0);
+            tableLayoutPanel1.Controls.Add(lblBeam, 2, 0);
+            tableLayoutPanel1.Controls.Add(lblRope, 1, 0);
             tableLayoutPanel1.Controls.Add(pnlMan, 0, 2);
             tableLayoutPanel1.Dock = DockStyle.Fill;
             tableLayoutPanel1.Location = new Point(775, 124);
@@ -643,55 +643,55 @@
             tableLayoutPanel1.Size = new Size(463, 519);
             tableLayoutPanel1.TabIndex = 3;
             // 
-            // label1
+            // lblBase
             // 
-            label1.AutoSize = true;
-            label1.BackColor = Color.Black;
-            tableLayoutPanel1.SetColumnSpan(label1, 5);
-            label1.Dock = DockStyle.Fill;
-            label1.Location = new Point(3, 459);
-            label1.Name = "label1";
-            label1.Size = new Size(457, 17);
-            label1.TabIndex = 1;
-            label1.Text = "label1";
+            lblBase.AutoSize = true;
+            lblBase.BackColor = Color.Black;
+            tableLayoutPanel1.SetColumnSpan(lblBase, 5);
+            lblBase.Dock = DockStyle.Fill;
+            lblBase.Location = new Point(3, 459);
+            lblBase.Name = "lblBase";
+            lblBase.Size = new Size(457, 17);
+            lblBase.TabIndex = 1;
+            lblBase.Text = "label1";
             // 
-            // label2
+            // lblPole
             // 
-            label2.AutoSize = true;
-            label2.BackColor = Color.Black;
-            label2.Dock = DockStyle.Fill;
-            label2.Location = new Point(302, 0);
-            label2.Margin = new Padding(0);
-            label2.Name = "label2";
-            tableLayoutPanel1.SetRowSpan(label2, 3);
-            label2.Size = new Size(14, 459);
-            label2.TabIndex = 2;
-            label2.Text = "label2";
+            lblPole.AutoSize = true;
+            lblPole.BackColor = Color.Black;
+            lblPole.Dock = DockStyle.Fill;
+            lblPole.Location = new Point(302, 0);
+            lblPole.Margin = new Padding(0);
+            lblPole.Name = "lblPole";
+            tableLayoutPanel1.SetRowSpan(lblPole, 3);
+            lblPole.Size = new Size(14, 459);
+            lblPole.TabIndex = 2;
+            lblPole.Text = "label2";
             // 
-            // label3
+            // lblBeam
             // 
-            label3.AutoSize = true;
-            label3.BackColor = Color.Black;
-            label3.Dock = DockStyle.Fill;
-            label3.Location = new Point(158, 0);
-            label3.Margin = new Padding(0);
-            label3.Name = "label3";
-            label3.Size = new Size(144, 17);
-            label3.TabIndex = 3;
-            label3.Text = "label3";
+            lblBeam.AutoSize = true;
+            lblBeam.BackColor = Color.Black;
+            lblBeam.Dock = DockStyle.Fill;
+            lblBeam.Location = new Point(158, 0);
+            lblBeam.Margin = new Padding(0);
+            lblBeam.Name = "lblBeam";
+            lblBeam.Size = new Size(144, 17);
+            lblBeam.TabIndex = 3;
+            lblBeam.Text = "label3";
             // 
-            // label4
+            // lblRope
             // 
-            label4.AutoSize = true;
-            label4.BackColor = Color.Black;
-            label4.Dock = DockStyle.Fill;
-            label4.Location = new Point(144, 0);
-            label4.Margin = new Padding(0);
-            label4.Name = "label4";
-            tableLayoutPanel1.SetRowSpan(label4, 2);
-            label4.Size = new Size(14, 114);
-            label4.TabIndex = 4;
-            label4.Text = "label4";
+            lblRope.AutoSize = true;
+            lblRope.BackColor = Color.Black;
+            lblRope.Dock = DockStyle.Fill;
+            lblRope.Location = new Point(144, 0);
+            lblRope.Margin = new Padding(0);
+            lblRope.Name = "lblRope";
+            tableLayoutPanel1.SetRowSpan(lblRope, 2);
+            lblRope.Size = new Size(14, 114);
+            lblRope.TabIndex = 4;
+            lblRope.Text = "label4";
             // 
             // pnlMan
             // 
@@ -844,10 +844,10 @@
         private RadioButton rdoMedium;
         private RadioButton rdoHard;
         private TableLayoutPanel tableLayoutPanel1;
-        private Label label1;
-        private Label label2;
-        private Label label3;
-        private Label label4;
+        private Label lblBase;
+        private Label lblPole;
+        private Label lblBeam;
+        private Label lblRope;
         private Panel pnlMan;
         private Label lblHead;
         private Label lblLeftLeg;

--- a/HangmanApp/HangmanApp/Form1.Designer.cs
+++ b/HangmanApp/HangmanApp/Form1.Designer.cs
@@ -34,6 +34,11 @@
             btnStart = new Button();
             btnGiveUp = new Button();
             lblMessage = new Label();
+            pnlDifficulty = new FlowLayoutPanel();
+            lblDifficulty = new Label();
+            rdoEasy = new RadioButton();
+            rdoMedium = new RadioButton();
+            rdoHard = new RadioButton();
             tblAlphabet = new TableLayoutPanel();
             btnA = new Button();
             btnB = new Button();
@@ -77,6 +82,7 @@
             lblHead = new Label();
             tblMain.SuspendLayout();
             tblToolbar.SuspendLayout();
+            pnlDifficulty.SuspendLayout();
             tblAlphabet.SuspendLayout();
             tblHiddenWord.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
@@ -90,6 +96,7 @@
             tblMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 62.22038F));
             tblMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 37.7796173F));
             tblMain.Controls.Add(tblToolbar, 0, 0);
+            tblMain.Controls.Add(pnlDifficulty, 0, 1);
             tblMain.Controls.Add(tblAlphabet, 0, 2);
             tblMain.Controls.Add(tblHiddenWord, 0, 3);
             tblMain.Controls.Add(tableLayoutPanel1, 1, 2);
@@ -162,6 +169,66 @@
             lblMessage.TabIndex = 2;
             lblMessage.Text = "Click start to begin game.";
             lblMessage.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // pnlDifficulty
+            // 
+            tblMain.SetColumnSpan(pnlDifficulty, 2);
+            pnlDifficulty.Controls.Add(lblDifficulty);
+            pnlDifficulty.Controls.Add(rdoEasy);
+            pnlDifficulty.Controls.Add(rdoMedium);
+            pnlDifficulty.Controls.Add(rdoHard);
+            pnlDifficulty.Dock = DockStyle.Fill;
+            pnlDifficulty.Location = new Point(3, 81);
+            pnlDifficulty.Name = "pnlDifficulty";
+            pnlDifficulty.Padding = new Padding(12, 6, 12, 6);
+            pnlDifficulty.Size = new Size(1235, 37);
+            pnlDifficulty.TabIndex = 4;
+            // 
+            // lblDifficulty
+            // 
+            lblDifficulty.Anchor = AnchorStyles.Left;
+            lblDifficulty.AutoSize = true;
+            lblDifficulty.Font = new Font("Segoe UI", 10.8F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            lblDifficulty.Location = new Point(15, 8);
+            lblDifficulty.Name = "lblDifficulty";
+            lblDifficulty.Size = new Size(86, 25);
+            lblDifficulty.TabIndex = 0;
+            lblDifficulty.Text = "Difficulty:";
+            // 
+            // rdoEasy
+            // 
+            rdoEasy.Anchor = AnchorStyles.Left;
+            rdoEasy.AutoSize = true;
+            rdoEasy.Checked = true;
+            rdoEasy.Location = new Point(107, 10);
+            rdoEasy.Name = "rdoEasy";
+            rdoEasy.Size = new Size(60, 24);
+            rdoEasy.TabIndex = 1;
+            rdoEasy.TabStop = true;
+            rdoEasy.Text = "Easy";
+            rdoEasy.UseVisualStyleBackColor = true;
+            // 
+            // rdoMedium
+            // 
+            rdoMedium.Anchor = AnchorStyles.Left;
+            rdoMedium.AutoSize = true;
+            rdoMedium.Location = new Point(173, 10);
+            rdoMedium.Name = "rdoMedium";
+            rdoMedium.Size = new Size(88, 24);
+            rdoMedium.TabIndex = 2;
+            rdoMedium.Text = "Medium";
+            rdoMedium.UseVisualStyleBackColor = true;
+            // 
+            // rdoHard
+            // 
+            rdoHard.Anchor = AnchorStyles.Left;
+            rdoHard.AutoSize = true;
+            rdoHard.Location = new Point(267, 10);
+            rdoHard.Name = "rdoHard";
+            rdoHard.Size = new Size(62, 24);
+            rdoHard.TabIndex = 3;
+            rdoHard.Text = "Hard";
+            rdoHard.UseVisualStyleBackColor = true;
             // 
             // tblAlphabet
             // 
@@ -723,6 +790,8 @@
             tblMain.ResumeLayout(false);
             tblToolbar.ResumeLayout(false);
             tblToolbar.PerformLayout();
+            pnlDifficulty.ResumeLayout(false);
+            pnlDifficulty.PerformLayout();
             tblAlphabet.ResumeLayout(false);
             tblHiddenWord.ResumeLayout(false);
             tblHiddenWord.PerformLayout();
@@ -769,6 +838,11 @@
         private Button btnY;
         private Button btnZ;
         private Label lblMessage;
+        private FlowLayoutPanel pnlDifficulty;
+        private Label lblDifficulty;
+        private RadioButton rdoEasy;
+        private RadioButton rdoMedium;
+        private RadioButton rdoHard;
         private TableLayoutPanel tableLayoutPanel1;
         private Label label1;
         private Label label2;

--- a/HangmanApp/HangmanApp/Form1.cs
+++ b/HangmanApp/HangmanApp/Form1.cs
@@ -14,8 +14,10 @@ namespace HangmanApp
         List<string> lstguessedletters;
         List<Button> lstalphabetbuttons;
         List<Label> lstbodyparts;
+        List<Label> lstgallowsparts;
         string hiddenword;
-        int guessesremaining = 6;
+        int guessesremaining = 7;
+        bool gallowsDrawn;
         enum DifficultyLevel { Easy, Medium, Hard }
         enum GameStatusEnum { NotStarted, Playing, GaveUp, Won, Lost };
         GameStatusEnum gamestatus = GameStatusEnum.NotStarted;
@@ -25,6 +27,7 @@ namespace HangmanApp
             lstguessedletters = new();
             lstalphabetbuttons = new();
             lstbodyparts = new() { lblHead, lblBody, lblLeftArm, lblRightArm, lblLeftLeg, lblRightLeg };
+            lstgallowsparts = new() { label1, label2, label3, label4 };
             foreach (Button b in tblAlphabet.Controls)
             {
                 lstalphabetbuttons.Add(b);
@@ -32,6 +35,7 @@ namespace HangmanApp
             lstalphabetbuttons.ForEach(b => b.Click += Letter_Click);
             btnStart.Click += BtnStart_Click;
             btnGiveUp.Click += BtnGiveUp_Click;
+            ChangeGameStatus(GameStatusEnum.NotStarted);
         }
 
         private void Letter_Click(object? sender, EventArgs e)
@@ -122,7 +126,9 @@ namespace HangmanApp
                     btnStart.Text = "Start";
                     btnGiveUp.Text = "Give Up";
                     lstguessedletters.Clear();
-                    guessesremaining = 6;
+                    guessesremaining = 7;
+                    gallowsDrawn = false;
+                    lstgallowsparts.ForEach(b => b.Visible = false);
                     lstbodyparts.ForEach(b => { b.Visible = false; b.ForeColor = Color.Black; });
                     lblBody.BackColor = Color.Black;
                     lstalphabetbuttons.ForEach(b => b.BackColor = Color.White);
@@ -234,7 +240,14 @@ namespace HangmanApp
         }
 
         private void AddBodyPart()
-        {//find the first body part in the list that isn't visible, and make it visible
+        {//show gallows first, then reveal body parts one at a time
+            if (!gallowsDrawn)
+            {
+                lstgallowsparts.ForEach(b => b.Visible = true);
+                gallowsDrawn = true;
+                return;
+            }
+
             var parttoshow = lstbodyparts.FirstOrDefault(b => !b.Visible);
             if (parttoshow != null) { parttoshow.Visible = true; }
         }

--- a/HangmanApp/HangmanApp/Form1.cs
+++ b/HangmanApp/HangmanApp/Form1.cs
@@ -27,7 +27,7 @@ namespace HangmanApp
             lstguessedletters = new();
             lstalphabetbuttons = new();
             lstbodyparts = new() { lblHead, lblBody, lblLeftArm, lblRightArm, lblLeftLeg, lblRightLeg };
-            lstgallowsparts = new() { label1, label2, label3, label4 };
+            lstgallowsparts = new() { lblBase, lblPole, lblBeam, lblRope };
             foreach (Button b in tblAlphabet.Controls)
             {
                 lstalphabetbuttons.Add(b);

--- a/HangmanApp/HangmanApp/Form1.cs
+++ b/HangmanApp/HangmanApp/Form1.cs
@@ -126,11 +126,13 @@ namespace HangmanApp
                     lstbodyparts.ForEach(b => { b.Visible = false; b.ForeColor = Color.Black; });
                     lblBody.BackColor = Color.Black;
                     lstalphabetbuttons.ForEach(b => b.BackColor = Color.White);
+                    SetDifficultySelectionEnabled(true);
                     break;
                 case GameStatusEnum.Playing:
                     btnGiveUp.Enabled = true;
                     btnStart.Enabled = false;
                     SetAlphabetButtonsEnabled(true);
+                    SetDifficultySelectionEnabled(false);
                     break;
                 case GameStatusEnum.Lost:
                     lstbodyparts.ForEach(b => b.ForeColor = Color.Red);
@@ -138,12 +140,14 @@ namespace HangmanApp
                     btnGiveUp.Text = "Reveal Word";
                     ResetStartButton();
                     SetAlphabetButtonsEnabled(false);
+                    SetDifficultySelectionEnabled(true);
                     break;
                 case GameStatusEnum.GaveUp:
                 case GameStatusEnum.Won:
                     ResetStartButton();
                     SetAlphabetButtonsEnabled(false);
                     btnGiveUp.Enabled = false;
+                    SetDifficultySelectionEnabled(true);
                     break;
             }
             UpdateMessage();
@@ -158,6 +162,13 @@ namespace HangmanApp
         {
             btnStart.Text = "Start New Game";
             btnStart.Enabled = true;
+        }
+
+        private void SetDifficultySelectionEnabled(bool enabled)
+        {
+            rdoEasy.Enabled = enabled;
+            rdoMedium.Enabled = enabled;
+            rdoHard.Enabled = enabled;
         }
 
         private void PickHiddenWord()
@@ -184,27 +195,24 @@ namespace HangmanApp
 
         private List<string> GetWordsForDifficulty(DifficultyLevel difficulty)
         {
-            List<string> sortedWords = lstwords
+            List<string> filteredWords = lstwords
+                .Where(word => difficulty switch
+                {
+                    DifficultyLevel.Easy => word.Length >= 3 && word.Length <= 4,
+                    DifficultyLevel.Medium => word.Length >= 5 && word.Length <= 6,
+                    DifficultyLevel.Hard => word.Length >= 7 && word.Length <= 10,
+                    _ => false
+                })
                 .OrderBy(word => word.Length)
                 .ThenBy(word => word)
                 .ToList();
 
-            if (sortedWords.Count < 3)
+            if (filteredWords.Count == 0)
             {
-                return sortedWords;
+                return lstwords;
             }
 
-            int easyCount = sortedWords.Count / 3;
-            int mediumCount = sortedWords.Count / 3;
-            int hardCount = sortedWords.Count - easyCount - mediumCount;
-
-            return difficulty switch
-            {
-                DifficultyLevel.Easy => sortedWords.Take(easyCount).ToList(),
-                DifficultyLevel.Medium => sortedWords.Skip(easyCount).Take(mediumCount).ToList(),
-                DifficultyLevel.Hard => sortedWords.Skip(easyCount + mediumCount).Take(hardCount).ToList(),
-                _ => sortedWords
-            };
+            return filteredWords;
         }
 
         private void BuildWordString()

--- a/HangmanApp/HangmanApp/Form1.cs
+++ b/HangmanApp/HangmanApp/Form1.cs
@@ -16,6 +16,7 @@ namespace HangmanApp
         List<Label> lstbodyparts;
         string hiddenword;
         int guessesremaining = 6;
+        enum DifficultyLevel { Easy, Medium, Hard }
         enum GameStatusEnum { NotStarted, Playing, GaveUp, Won, Lost };
         GameStatusEnum gamestatus = GameStatusEnum.NotStarted;
         public Form1()
@@ -161,8 +162,49 @@ namespace HangmanApp
 
         private void PickHiddenWord()
         {
-            hiddenword = lstwords[rnd.Next(lstwords.Count())];
+            List<string> wordsForDifficulty = GetWordsForDifficulty(GetSelectedDifficulty());
+            hiddenword = wordsForDifficulty[rnd.Next(wordsForDifficulty.Count)];
             BuildWordString();
+        }
+
+        private DifficultyLevel GetSelectedDifficulty()
+        {
+            if (rdoHard.Checked)
+            {
+                return DifficultyLevel.Hard;
+            }
+
+            if (rdoMedium.Checked)
+            {
+                return DifficultyLevel.Medium;
+            }
+
+            return DifficultyLevel.Easy;
+        }
+
+        private List<string> GetWordsForDifficulty(DifficultyLevel difficulty)
+        {
+            List<string> sortedWords = lstwords
+                .OrderBy(word => word.Length)
+                .ThenBy(word => word)
+                .ToList();
+
+            if (sortedWords.Count < 3)
+            {
+                return sortedWords;
+            }
+
+            int easyCount = sortedWords.Count / 3;
+            int mediumCount = sortedWords.Count / 3;
+            int hardCount = sortedWords.Count - easyCount - mediumCount;
+
+            return difficulty switch
+            {
+                DifficultyLevel.Easy => sortedWords.Take(easyCount).ToList(),
+                DifficultyLevel.Medium => sortedWords.Skip(easyCount).Take(mediumCount).ToList(),
+                DifficultyLevel.Hard => sortedWords.Skip(easyCount + mediumCount).Take(hardCount).ToList(),
+                _ => sortedWords
+            };
         }
 
         private void BuildWordString()


### PR DESCRIPTION
### Motivation
- Provide an in-UI difficulty choice so users can pick Easy/Medium/Hard which should yield shorter, longer, or longest hidden words respectively.  
- Use the existing `Words.txt` list as the source and partition it by word length to satisfy the short/longer/longest requirement.

### Description
- Added a difficulty row with three radio buttons (`rdoEasy`, `rdoMedium`, `rdoHard`) (Easy selected by default) and a `pnlDifficulty` container in `Form1.Designer.cs`.  
- Introduced `DifficultyLevel` enum and helper `GetSelectedDifficulty()` in `Form1.cs` to read the selected radio button.  
- Added `GetWordsForDifficulty(DifficultyLevel)` which sorts `lstwords` by length and splits the list into thirds (shortest → Easy, middle → Medium, longest → Hard) with a small-count fallback.  
- Updated `PickHiddenWord()` to choose the hidden word from the difficulty-specific pool instead of the full list; files modified: `HangmanApp/HangmanApp/Form1.cs` and `HangmanApp/HangmanApp/Form1.Designer.cs`.

### Testing
- Attempted to run `dotnet build HangmanApp/HangmanApp.slnx` but the build could not be executed in this environment because the `dotnet` CLI is not installed (error: `dotnet: command not found`).  
- No automated unit tests were run; changes were applied and the code files were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebab1762e0832a8925149c1be16cc6)